### PR TITLE
crypto: Fix mutex for single thread configuration

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -110,7 +110,11 @@ if (CONFIG_NRF_CC3XX_PLATFORM)
   # Add companion sources to directly to zephyr
   #
   zephyr_sources(${NRF_CC3XX_PLATFORM_BASE}/src/nrf_cc3xx_platform_abort_zephyr.c)
-  zephyr_sources(${NRF_CC3XX_PLATFORM_BASE}/src/nrf_cc3xx_platform_mutex_zephyr.c)
+  if (CONFIG_MULTITHREADING)
+    zephyr_sources(${NRF_CC3XX_PLATFORM_BASE}/src/nrf_cc3xx_platform_mutex_zephyr.c)
+  else()
+    zephyr_sources(${NRF_CC3XX_PLATFORM_BASE}/src/nrf_cc3xx_platform_no_mutex_zephyr.c)
+  endif()
 endif()
 
 if (CONFIG_CC3XX_BACKEND)

--- a/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
+++ b/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
@@ -10,6 +10,10 @@
 #include <zephyr.h>
 #include <kernel.h>
 
+BUILD_ASSERT(IS_ENABLED(CONFIG_MULTITHREADING),
+	"This file is intended for multi-threading, but single-threading is enabled. "
+	"Please check your config build configuration!");
+
 #if defined(NRF5340_XXAA_APPLICATION)
 #include <hal/nrf_mutex.h>
 #endif /* defined(NRF5340_XXAA_APPLICATION) */

--- a/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_no_mutex_zephyr.c
+++ b/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_no_mutex_zephyr.c
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <zephyr.h>
+
+BUILD_ASSERT(!IS_ENABLED(CONFIG_MULTITHREADING),
+	"This file is intended for single-threading, but multi-threading is enabled. "
+	"Please check your config build configuration!");
+
+/** @brief Function to initialize the nrf_cc3xx_platform mutex APIs
+ */
+void nrf_cc3xx_platform_mutex_init(void)
+{
+	// No thread-safe mutexes are required
+}

--- a/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
+++ b/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
@@ -10,6 +10,10 @@
 #include <zephyr.h>
 #include <kernel.h>
 
+BUILD_ASSERT(IS_ENABLED(CONFIG_MULTITHREADING),
+	"This file is intended for multi-threading, but single-threading is enabled. "
+	"Please check your config build configuration!");
+
 #if defined(NRF5340_XXAA_APPLICATION)
 #include <hal/nrf_mutex.h>
 #endif /* defined(NRF5340_XXAA_APPLICATION) */

--- a/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_no_mutex_zephyr.c
+++ b/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_no_mutex_zephyr.c
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <zephyr.h>
+
+BUILD_ASSERT(!IS_ENABLED(CONFIG_MULTITHREADING),
+	"This file is intended for single-threading, but multi-threading is enabled. "
+	"Please check your config build configuration!");
+
+/** @brief Function to initialize the nrf_cc3xx_platform mutex APIs
+ */
+void nrf_cc3xx_platform_mutex_init(void)
+{
+	// No thread-safe mutexes are required
+}

--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -1,8 +1,15 @@
 menu "Nordic Security"
 
+config NORDIC_SECURITY_PROMPTLESS
+	bool
+	help
+	  Internal setting to disable the Nordic security backend
+	  This setting is Kconfig internal that must be used by subsystems that
+	  provides nRF Security selection groups.
+
 config NORDIC_SECURITY_BACKEND
 	bool
-	prompt "Use Nordic provided security backend"
+	prompt "Use Nordic provided security backend" if !NORDIC_SECURITY_PROMPTLESS
 	depends on SOC_FAMILY_NRF
 	select NRFXLIB_CRYPTO
 	select ENTROPY_GENERATOR if (SOC_NRF52810 || SOC_NRF52832)


### PR DESCRIPTION
-This solves nrf_security build problems when MULTITHREADING is set to false
 (single threading support is un-deprecated in the ongoing upmerge)
-Adds "no mutex" to not call any APIs related to this

NOTE: PR pointing to @tejlmand's branch, as this is used in the upmerge

ref: NCSDK-9650

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>